### PR TITLE
Added capacity for an optional custom stylesheet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ wp-content/plugins/hello.php
 /sitemap.xml
 /sitemap.xml.gz
 
+ra_custom.css

--- a/functions.php
+++ b/functions.php
@@ -43,7 +43,25 @@ function cioos_customize_logo() {
    }
 }
 
+/**
+ * Checks for the existance of a stylesheet named ra_custom.css, if found it 
+ * loads it with a lower priority than the parent and theme styles to be sure 
+ * and be last in the styling order to avoid being overridden.
+ */
+function cioos_custom_stylesheet() {
+   # custom CSS url for browser
+   $custom_css_url = get_stylesheet_directory_uri() . '/ra_custom.css';
+   
+   # used to check for existance of custom file
+   $custom_css_path = get_stylesheet_directory() . '/ra_custom.css';
+   if (file_exists($custom_css_path)) {
+      wp_enqueue_style( 'ra-custom-style', $custom_css_url, array('parent-style'));
+   }
+}
+
 add_action( 'wp_enqueue_scripts', 'enqueue_parent_styles' );
+add_action( 'wp_enqueue_scripts', 'cioos_custom_stylesheet', 50000);
 add_action( 'customize_register', 'cioos_customize_register');
 add_action( 'wp_head', 'cioos_customize_logo' );
+
 ?>

--- a/ra_custom.sample.css
+++ b/ra_custom.sample.css
@@ -1,0 +1,11 @@
+/*
+Rename this file to ra_custom.css to be added to your 
+wordpress deployment as a low priority css file.
+*/
+
+h1 {
+  color: red !important;
+  font-size: 1.5em;
+  font-weight: bold;
+  text-decoration: underline;
+}


### PR DESCRIPTION
A desire was expressed at the Atlantic RA to be able to track base styling changes when customizing the WordPress site.  An optional, late priority stylesheet could accomplish this in a version controlled way that didn't involve hiding them in a theme setting or fracturing the trunk.

A sample sylesheet is provided to show an example of a change made in this way: h1 tags are now red, larger and underlined.  Renaming the file to ra_custom.css will enable the file to be enqueued dependant on the parent style being loaded first and set at a very low priority setting on the add_action() call.

ra_custom.css should not be tracked in the master branch - RAs should manage their style changes either in a dedicated separate branch or a separate repository.