### PR TITLE
Add options for French and English footer Copyright text, used by Polylang

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -46,4 +46,49 @@ function cioos_customize_logo() {
 add_action( 'wp_enqueue_scripts', 'enqueue_parent_styles' );
 add_action( 'customize_register', 'cioos_customize_register');
 add_action( 'wp_head', 'cioos_customize_logo' );
+
+function register_copyright_config_for_locale( $wp_customize, $locale ) {
+   $setting_id = 'wrt_copyright_'.$locale;
+   $control_id = 'cioos_wrt_copyright_'.$locale;
+
+   $wp_customize->add_setting( $setting_id );
+   $wp_customize->add_control( $control_id, array(
+       'label'   => __( 'Copyright Text ', 'CIOOS').$locale,
+       'type'    => 'text',
+       'section' => 'title_tagline',
+       'settings' => $setting_id,
+   ) );
+}
+
+function cioos_customize_copyright_register($wp_customize) {
+   $locales = [
+       'en_CA',
+       'fr_CA'
+   ];
+   foreach ( $locales as $locale) {
+      register_copyright_config_for_locale($wp_customize, $locale);
+   }
+}
+
+function cioos_customize_copyright() {
+   global $thinkup_footer_copyright;
+
+   if (function_exists('pll_current_language')) {
+      $locale = pll_current_language('locale');
+      $setting_id = 'wrt_copyright_' . $locale;
+      if ( get_theme_mod( $setting_id ) ) {
+         $thinkup_footer_copyright = get_theme_mod( $setting_id );
+      } else {
+         if ( get_theme_mod('wrt_copyright') ) {
+            $thinkup_footer_copyright = get_theme_mod('wrt_copyright');
+         } else {
+            $thinkup_footer_copyright = get_theme_mod( 'wrt_copyright_en_CA' );
+         }
+      }
+   }
+}
+
+add_action( 'customize_register', 'cioos_customize_copyright_register');
+add_action( 'wp_head', 'cioos_customize_copyright' );
+
 ?>


### PR DESCRIPTION
This enables entering both French and English Copyright text in the WordPress footer, similar to the how the logo switches/based on that work. The text fields can be found under Customize/Site Identity with both locales available. The code could be streamlined a bit into the existing functions such as locale setting to reduce some repetition.