### PR TITLE
Pacific RA's asset map embed

### DIFF
--- a/front-page.php
+++ b/front-page.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * The template for displaying all pages.
+ *
+ * This is the template that displays all pages by default.
+ *
+ * @package ThinkUpThemes
+ */
+
+get_header(); ?>
+
+<!-- Add in the containers the asset map needs -->
+
+<div class="outer-map-container" id="intro-core">
+  <div class="overlay"></div>
+  <div class="map-container" id="asset_map_container">
+    <div id="map" class="map" ></div>
+    <div id="category_panel" class="category-selection"></div>
+    <div id="variable_panel" class="variable-selection tab-content"></div>
+    <div id="dataset_desc" class="panel_details"></div>
+    <div class="panel_search_info" style="text-align:center" id="dataset_search_stats"></div>
+  </div>
+</div>
+  
+
+<?php while ( have_posts() ) : the_post(); ?>
+<?php get_template_part( 'content', 'page' ); ?>
+<?php endwhile; wp_reset_query(); ?>
+
+
+
+<?php get_footer(); ?>
+
+<?php    //Language switch system - this will reload the map on WP switch
+  function inlinejs($output) {
+    $js_code = '<script>' . $output . '</script>';
+    echo $js_code;
+  }
+  if(pll_current_language() == 'en') {
+    $lang = 'jQuery(document).ready(function( $ ) {changeCurrentLanguage(\'en\')});';
+    inlinejs($lang);
+  } else if(pll_current_language() == 'fr') {
+    $lang = 'jQuery(document).ready(function( $ ) {changeCurrentLanguage(\'fr\')});'; 
+    inlinejs($lang); 
+  }; 
+?>

--- a/functions.php
+++ b/functions.php
@@ -3,6 +3,33 @@ function enqueue_parent_styles() {
    wp_enqueue_style( 'parent-style', get_template_directory_uri().'/style.css' );
 }
 
+//==================================================================================
+// Asset Map JS
+//==================================================================================
+
+ function assetmap_scripts() {
+     if( is_front_page() ){ 
+     // CSS
+       wp_enqueue_style( 'asset-style', get_stylesheet_directory_uri().'/cioos-siooc-assetmap/asset/css/asset.css' );
+       wp_enqueue_style( 'map-style', get_stylesheet_directory_uri().'/cioos-siooc-assetmap/asset/css/ol.css' );
+     
+     // SCRIPTS
+         wp_enqueue_script( 'map-build','https:/cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/build/ol.js', array('jquery'), '', false  );
+         wp_enqueue_script( 'i18', get_stylesheet_directory_uri() . '/cioos-siooc-assetmap/asset/js/asset_i18n.js', array('jquery'), '', false   );
+         wp_enqueue_script( 'assetckan', get_stylesheet_directory_uri() . '/cioos-siooc-assetmap/asset/js/asset_ckan.js', array('jquery'), '', false   );
+         wp_enqueue_script( 'assetgeneral', get_stylesheet_directory_uri() . '/cioos-siooc-assetmap/asset/js/asset.js', array('jquery'), '', false   );
+         wp_enqueue_script( 'assetui', get_stylesheet_directory_uri() . '/cioos-siooc-assetmap/asset/js/asset_ui.js', array('jquery'), '', false   );
+         wp_enqueue_script( 'assetol', get_stylesheet_directory_uri() . '/cioos-siooc-assetmap/asset/js/asset_ol.js', array('jquery'), '', true   );
+     }
+     
+ }
+
+ add_action( 'wp_enqueue_scripts', 'assetmap_scripts', 10);
+
+//==================================================================================
+// The Rest
+//==================================================================================
+
 function register_logo_config_for_locale( $wp_customize, $locale ) {
    $setting_id = 'logo_'.$locale;
    $control_id = 'cioos_logo_'.$locale;

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@ Description: The WordPress theme created for the CIOOS National Site and RAs
 Author: OGSL
 Author URL: https://ogsl.ca/
 Template: Experon_Pro
-Version: 1.0.0
+Version: 1.0.1
 Text Domain: CIOOS
 */
 


### PR DESCRIPTION
This is what Pacific needs to display the Asset map in the child Theme.  This can be applied to any RA, or the national site. if you like. Some changes to the map files are going to be needed. See the branch "WordPressProxyWorkaround" in cioos-siooc-assetmap for that.